### PR TITLE
fix(scripts): keep only protein sequences

### DIFF
--- a/scripts/download_pdb_seqres.sh
+++ b/scripts/download_pdb_seqres.sh
@@ -37,4 +37,9 @@ SOURCE_URL="ftp://ftp.pdbj.org/pub/pdb/derived_data/pdb_seqres.txt"
 
 mkdir --parents "${ROOT_DIR}"
 aria2c -x16 -j16 --allow-overwrite "${SOURCE_URL}" --dir="${ROOT_DIR}"
+# Keep only protein sequences.
+grep --after-context=1 --no-group-separator '>.* mol:protein' \
+	"${ROOT_DIR}/pdb_seqres.txt" > "${ROOT_DIR}/pdb_seqres_filtered.txt"
+mv "${ROOT_DIR}/pdb_seqres_filtered.txt" "${ROOT_DIR}/pdb_seqres.txt"
+
 "$SCRIPT_DIR/filter_pdb_seqres.py" "${ROOT_DIR}/pdb_seqres.txt"


### PR DESCRIPTION
This is a partial cherry-pick of deepmind/alphafold@9b18d6a966b9b08b2095dd77d8414a68d3d31fc9.
Fixes #4.